### PR TITLE
KanBan003 - Delete Tasking

### DIFF
--- a/BackEnd/server.js
+++ b/BackEnd/server.js
@@ -67,6 +67,18 @@ db.serialize(() => {
     });
   });
 
+  app.delete('/:taskId/deletetask', (req, res) => {
+    const taskId = req.params.taskId;
+  
+    db.run('DELETE FROM tasks WHERE id = ?', [taskId], (err, rows) => {
+      if (err) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      res.json(rows);
+    });
+  });
+
   app.get('/projects/:projectId/tasks', (req, res) => {
     const projectId = req.params.projectId;
   

--- a/FrontEnd/KanBanBoard/src/app/project.service.ts
+++ b/FrontEnd/KanBanBoard/src/app/project.service.ts
@@ -30,11 +30,11 @@ export class ProjectService {
     return this.http.post<any>(`${this.baseUrl}/projects/${projectId}/tasks`, task);
   }
 
+  deleteTaskById(taskId: number): Observable<any> {
+    return this.http.delete<any>(`${this.baseUrl}/${taskId}/deletetask`);
+  }
+
   updateTaskState(taskId: number, newState: string): Observable<any> {
-    console.log("taskId");
-    console.log(taskId);
-    console.log("newState");
-    console.log(newState);
     return this.http.patch(`${this.baseUrl}/tasks/${taskId}/state`, { state: newState });
   }
 }

--- a/FrontEnd/KanBanBoard/src/app/task-list-card/task-list-card.component.html
+++ b/FrontEnd/KanBanBoard/src/app/task-list-card/task-list-card.component.html
@@ -14,4 +14,8 @@
     <mat-card-content>
         {{task.state}}
     </mat-card-content>
+
+    <button mat-fab matTooltip="Primary" color="primary" (click)="deleteTask(task.id)">
+        <mat-icon>delete</mat-icon>
+      </button>
   </mat-card>

--- a/FrontEnd/KanBanBoard/src/app/task-list-card/task-list-card.component.ts
+++ b/FrontEnd/KanBanBoard/src/app/task-list-card/task-list-card.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
 
+import { ProjectService } from '../project.service';
+
 @Component({
   selector: 'app-task-list-card',
   templateUrl: './task-list-card.component.html',
@@ -7,5 +9,20 @@ import { Component, Input } from '@angular/core';
 })
 export class TaskListCardComponent {
   @Input() task: any;
+
+  constructor(private projectService: ProjectService) {}
+
+  deleteTask(id: number) {
+    console.log(id);
+    this.projectService.deleteTaskById(id).subscribe(
+      response => {
+        console.log('Delete response:', response);
+      },
+      error => {
+        console.error('There was an error connecting to backend, cant delete Task!', error);
+        console.error('Delete error:', error);
+      }
+    );
+  }
 
 }


### PR DESCRIPTION
Added delete functionality for tasking, changed server.js with an addition of a delete route, task-ist-card both HTML and TypeScript has deleteTask(task.id) which references app.service.ts's new deleteTaskById method which uses the backends new delete route. 